### PR TITLE
Update PHP version to 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
     "doctrine/instantiator": "^2.0",
     "atto/codegen-tools": "dev-main",
     "roave/better-reflection": "^6.25",


### PR DESCRIPTION
[traits can only contain constants in PHP >= 8.2.](https://php.watch/versions/8.2/constants-in-traits)

https://github.com/atto-php/hydrator/blob/93df6961314e45d0968ff2fbe3153e3b7d9d0f50/src/Template/Extract/BasicExtract.php#L10-L16

Since it would not have worked correctly on 8.1, this does not break backwards compatibility. This would be considered a bug fix.

