### PR TITLE
Use Laminas CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+name: "Continuous Integration"
+
+on:
+  pull_request:
+  push:
+    branches:
+    tags:
+
+jobs:
+  ci:
+    uses: laminas/workflow-continuous-integration/.github/workflows/continuous-integration.yml@1.x

--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,13 @@
+{
+  "additional_checks": [
+    {
+      "name": "PHPStan",
+      "job": {
+        "php": "*",
+        "dependencies": "*",
+        "command": "vendor/bin/phpstan analyse"
+      }
+    }
+  ],
+  "stablePHP": "8.0"
+}


### PR DESCRIPTION
With the test suite taking shape, it would be beneficial to have a CI pipeline running on PRs.