### PR TITLE
Add Hydratable Attribute to all test fixtures

### DIFF
--- a/tests/fixtures/Fixture/WithArrays/OfEnums/IntBacked.php
+++ b/tests/fixtures/Fixture/WithArrays/OfEnums/IntBacked.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithArrays\OfEnums;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\Attribute\SerializationStrategy;
 use Atto\Hydrator\Attribute\SerializationStrategyType;
 use Atto\Hydrator\Attribute\Subtype;
 use Atto\Hydrator\TestFixtures\Fixture;
 use Atto\Hydrator\TestFixtures\Mocks\Enums\IntDummy;
 
+#[Hydratable]
 final class IntBacked implements Fixture
 {
     public function __construct(

--- a/tests/fixtures/Fixture/WithArrays/OfEnums/StringBacked.php
+++ b/tests/fixtures/Fixture/WithArrays/OfEnums/StringBacked.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithArrays\OfEnums;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\Attribute\SerializationStrategy;
 use Atto\Hydrator\Attribute\SerializationStrategyType;
 use Atto\Hydrator\Attribute\Subtype;
 use Atto\Hydrator\TestFixtures\Fixture;
 use Atto\Hydrator\TestFixtures\Mocks\Enums\StringDummy;
 
+#[Hydratable]
 final class StringBacked implements Fixture
 {
     public function __construct(

--- a/tests/fixtures/Fixture/WithArrays/OfObjects/WithScalars/Bools.php
+++ b/tests/fixtures/Fixture/WithArrays/OfObjects/WithScalars/Bools.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithArrays\OfObjects\WithScalars;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\Attribute\HydrationStrategy;
 use Atto\Hydrator\Attribute\HydrationStrategyType;
 use Atto\Hydrator\Attribute\Subtype;
 use Atto\Hydrator\TestFixtures\Fixture;
 use RuntimeException;
 
+#[Hydratable]
 final class Bools implements Fixture
 {
     /**

--- a/tests/fixtures/Fixture/WithArrays/OfScalars/Bools.php
+++ b/tests/fixtures/Fixture/WithArrays/OfScalars/Bools.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Atto\Hydrator\TestFixtures\Fixture\WithArrays\OfScalars;
 
 use Atto\Hydrator\Attribute\Hydratable;
-use Atto\Hydrator\Attribute\HydrationStrategy;
-use Atto\Hydrator\Attribute\HydrationStrategyType;
 use Atto\Hydrator\Attribute\SerializationStrategy;
 use Atto\Hydrator\Attribute\SerializationStrategyType;
 use Atto\Hydrator\Attribute\Subtype;
 use Atto\Hydrator\TestFixtures\Fixture;
 
+#[Hydratable]
 final class Bools implements Fixture
 {
     /**

--- a/tests/fixtures/Fixture/WithArrays/OfScalars/Floats.php
+++ b/tests/fixtures/Fixture/WithArrays/OfScalars/Floats.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithArrays\OfScalars;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\Attribute\SerializationStrategy;
 use Atto\Hydrator\Attribute\SerializationStrategyType;
 use Atto\Hydrator\Attribute\Subtype;
 use Atto\Hydrator\TestFixtures\Fixture;
 
+#[Hydratable]
 final class Floats implements Fixture
 {
     /**

--- a/tests/fixtures/Fixture/WithArrays/OfScalars/Integers.php
+++ b/tests/fixtures/Fixture/WithArrays/OfScalars/Integers.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithArrays\OfScalars;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\Attribute\SerializationStrategy;
 use Atto\Hydrator\Attribute\SerializationStrategyType;
 use Atto\Hydrator\Attribute\Subtype;
 use Atto\Hydrator\TestFixtures\Fixture;
 
+#[Hydratable]
 final class Integers implements Fixture
 {
     /**

--- a/tests/fixtures/Fixture/WithArrays/OfScalars/Strings.php
+++ b/tests/fixtures/Fixture/WithArrays/OfScalars/Strings.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithArrays\OfScalars;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\Attribute\SerializationStrategy;
 use Atto\Hydrator\Attribute\SerializationStrategyType;
 use Atto\Hydrator\Attribute\Subtype;
 use Atto\Hydrator\TestFixtures\Fixture;
 
+#[Hydratable]
 final class Strings implements Fixture
 {
     /**

--- a/tests/fixtures/Fixture/WithDateTimes.php
+++ b/tests/fixtures/Fixture/WithDateTimes.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\Attribute\HydrationStrategy;
 use Atto\Hydrator\Attribute\HydrationStrategyType;
 use Atto\Hydrator\TestFixtures\Fixture;
 use DateTime;
 
+#[Hydratable]
 final class WithDateTimes implements Fixture
 {
     private DateTime $unset;

--- a/tests/fixtures/Fixture/WithEnums/IntBacked.php
+++ b/tests/fixtures/Fixture/WithEnums/IntBacked.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithEnums;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\Attribute\HydrationStrategy;
 use Atto\Hydrator\Attribute\HydrationStrategyType;
 use Atto\Hydrator\TestFixtures\Fixture;
 use Atto\Hydrator\TestFixtures\Mocks\Enums\IntDummy;
 
+#[Hydratable]
 final class IntBacked implements Fixture
 {
     private IntDummy $unset;

--- a/tests/fixtures/Fixture/WithEnums/StringBacked.php
+++ b/tests/fixtures/Fixture/WithEnums/StringBacked.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithEnums;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\Attribute\HydrationStrategy;
 use Atto\Hydrator\Attribute\HydrationStrategyType;
 use Atto\Hydrator\TestFixtures\Fixture;
 use Atto\Hydrator\TestFixtures\Mocks\Enums\StringDummy;
 
+#[Hydratable]
 final class StringBacked implements Fixture
 {
     private StringDummy $unset;

--- a/tests/fixtures/Fixture/WithObjects/WithDateTimes.php
+++ b/tests/fixtures/Fixture/WithObjects/WithDateTimes.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithObjects;
 
-use Atto\Hydrator\{TestFixtures\Fixture};
-use Atto\Hydrator\Attribute\SerializationStrategy;
-use Atto\Hydrator\Attribute\SerializationStrategyType;
+use Atto\Hydrator\{Attribute\Hydratable, TestFixtures\Fixture};
 
+#[Hydratable]
 final class WithDateTimes implements Fixture
 {
     public function __construct(

--- a/tests/fixtures/Fixture/WithObjects/WithScalars/Floats.php
+++ b/tests/fixtures/Fixture/WithObjects/WithScalars/Floats.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithObjects\WithScalars;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\Attribute\HydrationStrategy;
 use Atto\Hydrator\Attribute\HydrationStrategyType;
 use Atto\Hydrator\TestFixtures\Fixture;
 
+#[Hydratable]
 final class Floats implements Fixture
 {
     public function __construct(

--- a/tests/fixtures/Fixture/WithObjects/WithScalars/Integers.php
+++ b/tests/fixtures/Fixture/WithObjects/WithScalars/Integers.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithObjects\WithScalars;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\Attribute\HydrationStrategy;
 use Atto\Hydrator\Attribute\HydrationStrategyType;
 use Atto\Hydrator\TestFixtures\Fixture;
 
+#[Hydratable]
 final class Integers implements Fixture
 {
     public function __construct(

--- a/tests/fixtures/Fixture/WithObjects/WithScalars/Strings.php
+++ b/tests/fixtures/Fixture/WithObjects/WithScalars/Strings.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithObjects\WithScalars;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\Attribute\HydrationStrategy;
 use Atto\Hydrator\Attribute\HydrationStrategyType;
 use Atto\Hydrator\TestFixtures\Fixture;
 
+#[Hydratable]
 final class Strings implements Fixture
 {
     public function __construct(

--- a/tests/fixtures/Fixture/WithScalars/Bools.php
+++ b/tests/fixtures/Fixture/WithScalars/Bools.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithScalars;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\TestFixtures\Fixture;
 
+#[Hydratable]
 final class Bools implements Fixture
 {
     private bool $unset;

--- a/tests/fixtures/Fixture/WithScalars/Floats.php
+++ b/tests/fixtures/Fixture/WithScalars/Floats.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithScalars;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\TestFixtures\Fixture;
 
+#[Hydratable]
 final class Floats implements Fixture
 {
     private float $unset;

--- a/tests/fixtures/Fixture/WithScalars/Integers.php
+++ b/tests/fixtures/Fixture/WithScalars/Integers.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithScalars;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\TestFixtures\Fixture;
 
+#[Hydratable]
 final class Integers implements Fixture
 {
     private int $unset;

--- a/tests/fixtures/Fixture/WithScalars/Strings.php
+++ b/tests/fixtures/Fixture/WithScalars/Strings.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Atto\Hydrator\TestFixtures\Fixture\WithScalars;
 
+use Atto\Hydrator\Attribute\Hydratable;
 use Atto\Hydrator\TestFixtures\Fixture;
 
+#[Hydratable]
 final class Strings implements Fixture
 {
     private string $unset;


### PR DESCRIPTION
Add `Hydratable` to all fixtures so they can be generated more easily during development.