### PR TITLE
Initialize propertyAccessors

### DIFF
--- a/src/Template/Closure.php
+++ b/src/Template/Closure.php
@@ -12,7 +12,7 @@ final class Closure
         EOF;
 
 
-    private array $propertyAccessors;
+    private array $propertyAccessors = [];
 
     public function __construct(
         private readonly string $className


### PR DESCRIPTION
If no properties exist, propertyAccessors never gets initialized.

This would cause errors when trying to generate a Hydrator for it.

By initializing it as an empty array, we avoid the issue.