### PR TITLE
Ignore generated/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 composer.lock
 composer.phar
+generated/
 .phpunit.cache/
 vendor/
-


### PR DESCRIPTION
When testing locally, I tend to use --out_directory=generated. As such it would be convenient to ignore it.
This way it cannot be accidentally added to commits.